### PR TITLE
fix dependency on "attrs" module; it was misspelled as "attr"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,5 +39,5 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = ">=3.5"
-attr = "*"
+attrs = "*"
 


### PR DESCRIPTION
While packaging dephell for Arch Linux I discovered that this was incorrect and prevented dephell from running.