### PR TITLE
python 3.8 compat: ast.Str is deprecated and should use ast.Constant

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,8 @@ matrix:
       env: ENV=pytest
     - python: "3.7-dev"
       env: ENV=pytest
+    - python: "3.8-dev"
+      env: ENV=pytest
     - python: "pypy3.5"
       env: ENV=pytest
 

--- a/dephell_discover/_line.py
+++ b/dephell_discover/_line.py
@@ -9,10 +9,15 @@ from ._constants import DOCSTRING
 
 
 def _get_str(node) -> Optional[str]:
-    if type(node) is ast.Str:
-        return node.s
-    if sys.version_info[:2] >= (3, 8):
-        if type(node) is getattr(ast.Constant):
+    # python <3.8
+    if sys.version_info[:2] < (3, 8):
+        if type(node) is ast.Str:
+            return node.s
+        return None
+
+    # python >=3.8
+    if type(node) is ast.Constant:
+        if type(node.value) is str:
             return node.value
     return None
 

--- a/dephell_discover/_line.py
+++ b/dephell_discover/_line.py
@@ -1,11 +1,16 @@
 import ast
 from pathlib import Path
+import sys
 from typing import Optional
 
 import attr
 
 from ._constants import DOCSTRING
 
+if sys.version_info[:2] >= (3,8):
+    _ast_str = ast.Constant
+else:
+    _ast_str = ast.Str
 
 @attr.s(frozen=True)
 class Line:
@@ -53,7 +58,7 @@ class Line:
         value = tree.body[0].value  # type: ignore
 
         # get string
-        if type(value) is ast.Str:
+        if type(value) is _ast_str:
             return cls(
                 target=target.id,
                 value=value.s,
@@ -65,7 +70,7 @@ class Line:
         # get list
         if type(value) is ast.List or type(value) is ast.Tuple:
             for element in value.elts:
-                if type(element) is not ast.Str:
+                if type(element) is not _ast_str:
                     return None
             return cls(
                 target=target.id,

--- a/dephell_discover/_line.py
+++ b/dephell_discover/_line.py
@@ -67,7 +67,7 @@ class Line:
         if value:
             return cls(
                 target=target.id,
-                value=value.s,
+                value=value,
                 content=content,
                 row=row,
                 path=path,


### PR DESCRIPTION
They are no longer the same types, and therefore the tests fail.

Fixes #8