### PR TITLE
fix default package_dir

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
 language: python
 
+# do not run Travis for PR's twice (as for push and as for PR)
+branches:
+  only:
+    - master
+
 before_install:
   # show a little bit more information about environment
   - sudo apt-get install -y tree

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ root.data
 # {Data(path=Path('../dephell/dephell/templates'), ext='.j2', package=Package(...)), ...}
 
 root.package_dir
-# {'': ''}
+# {'': '.'}
 ```
 
 Package properties:

--- a/dephell_discover/_root.py
+++ b/dephell_discover/_root.py
@@ -40,7 +40,7 @@ class Root:
             return {self.name: ''}
 
         # when packages placed in the dirs by package names
-        return {'': ''}
+        return {'': '.'}
 
     @cached_property
     def packages(self) -> List[Package]:
@@ -116,7 +116,7 @@ class Root:
     def _get_module_name(self, path: Path) -> str:
         parts = list(path.parts[len(self.path.parts):])
         root_name, root_dir = next(iter(self.package_dir.items()))
-        if root_dir == '':
+        if root_dir in ('', '.'):
             parts.insert(0, root_name)
         elif parts and parts[0] == root_dir:
             parts = [root_name] + parts[1:]

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -40,7 +40,7 @@ def test_discover_packages(tmp_path):
 
 
 @pytest.mark.parametrize('files, expected', [
-    [('foobar/__init__.py', 'foobar/foo.py', 'foobar/bar.py'), {'': ''}],
+    [('foobar/__init__.py', 'foobar/foo.py', 'foobar/bar.py'), {'': '.'}],
     [('src/__init__.py', 'src/foo.py', 'src/bar.py'), {'foobar': 'src'}],
     [('src/foo.py', 'src/bar.py'), {'': 'src'}],
     [('__init__.py', 'foo.py', 'bar.py'), {'foobar': ''}],


### PR DESCRIPTION
Fix https://github.com/dephell/dephell/pull/291#issuecomment-552923856

This is a strange behavior of distutils (setuptools is also affected). Command `egg_info` can not handle `""` path to the project, only `"."`