### PR TITLE
Ignore sibling directories if `src/` is present

### DIFF
--- a/dephell_discover/_root.py
+++ b/dephell_discover/_root.py
@@ -46,9 +46,13 @@ class Root:
     def packages(self) -> List[Package]:
         packages = []
 
-        root = self.path / self.name.replace('-', '_')
+        src = self.path / 'src'
+        if not src.exists():
+            src = self.path
+
+        root = src / self.name.replace('-', '_')
         if not root.exists():
-            root = self.path
+            root = src
 
         for path in root.glob('**/__init__.py'):
             if self.include(path=path):

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -101,7 +101,7 @@ def test_packages_module(files, expected_modules, tmp_path):
 
 @pytest.mark.parametrize('files, expected_paths', [
     [('foobar/__init__.py', 'foobar/foo.py', 'foobar/bar.py'), {'foobar'}],
-    [('src/__init__.py', 'src/foo.py', 'src/bar.py'), {'src'}],
+    [('src/__init__.py', 'src/foo.py', 'src/bar.py', 'tasks/__init__.py', 'script.py'), {'src'}],
     # [('src/foo.py', 'src/bar.py'), {'src/'}],
     [('__init__.py', 'foo.py', 'bar.py'), {''}],
     [('src/foobar/__init__.py', 'src/foobar/foo.py', 'src/foobar/bar.py'), {'src/foobar'}],


### PR DESCRIPTION
Problem: Projects with `src/` layouts might put arbitrary other things next to that. An example might be `tasks/__init__.py` for [Invoke](http://www.pyinvoke.org) projects. While `dephell_discover` is already aware of the `src/` convention, it will consider packages next to it as candidates.

Solution: If there's an `src` folder, limit scanning to that folder.